### PR TITLE
Properly import the Image module from PIL(low)

### DIFF
--- a/src/picker/wxPickerView.py
+++ b/src/picker/wxPickerView.py
@@ -23,7 +23,7 @@ import app
 import utils
 import wx
 try:
-    import Image
+    from PIL import Image
 except:
     utils.make_err_msg(_("Python Imaging Library (PIL) not found.\nRefer to readme file for install instructions.\n\nYou will not be able to preview images."),
                        _("PIL needed"))


### PR DESCRIPTION
Before, it was just trying to find a module named Image at the root of the python library directory.